### PR TITLE
Add python 3.12 support for musllinux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           output-dir: dist
 
@@ -155,7 +155,7 @@ jobs:
           platforms: arm64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           output-dir: dist
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           output-dir: dist
 
@@ -154,7 +154,7 @@ jobs:
           platforms: arm64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           output-dir: dist
 


### PR DESCRIPTION
Update cibuildwheel version to build wheels for python 3.12 for musllinux_x86_64 and musllinux_aarch64.